### PR TITLE
Accounting for the non use of the rails_warden gem

### DIFF
--- a/lib/warden/test/controller_helpers.rb
+++ b/lib/warden/test/controller_helpers.rb
@@ -31,7 +31,7 @@ module Warden
       # Quick access to Warden::Proxy.
       def warden
         @warden ||= begin
-          manager = Warden::Manager.new(nil, &Rails.application.config.middleware.detect{|m| m.name == 'RailsWarden::Manager'}.block)
+          manager = Warden::Manager.new(nil, &Rails.application.config.middleware.detect{|m| m.name == 'RailsWarden::Manager' or m.name == 'Warden::Manager'}.block)
           @request.env['warden'] = Warden::Proxy.new(@request.env, manager)
         end
       end

--- a/lib/warden/test/controller_helpers.rb
+++ b/lib/warden/test/controller_helpers.rb
@@ -31,7 +31,7 @@ module Warden
       # Quick access to Warden::Proxy.
       def warden
         @warden ||= begin
-          manager = Warden::Manager.new(nil, &Rails.application.config.middleware.detect{|m| m.name == 'RailsWarden::Manager' or m.name == 'Warden::Manager'}.block)
+          manager = Warden::Manager.new(nil, &Rails.application.config.middleware.detect{|m| m.name == 'RailsWarden::Manager' || m.name == 'Warden::Manager'}.block)
           @request.env['warden'] = Warden::Proxy.new(@request.env, manager)
         end
       end


### PR DESCRIPTION
This will allow the gem to work even if RailsWarden is not being used.  It will look for the plain Warden middleware also.
