### PR TITLE
Updated helpers to work with RoR 4.1 & RSpec 3

### DIFF
--- a/lib/warden/test/controller_helpers.rb
+++ b/lib/warden/test/controller_helpers.rb
@@ -1,5 +1,6 @@
 # test/test_helpers/warden.rb
 
+# Based on http://stackoverflow.com/questions/13420923/configuring-warden-for-use-in-rspec-controller-specs
 module Warden
   # Warden::Test::ControllerHelpers provides a facility to test controllers in isolation
   # Most of the code was extracted from Devise's Devise::TestHelpers.
@@ -7,13 +8,7 @@ module Warden
     module ControllerHelpers
       def self.included(base)
         base.class_eval do
-          before(:each) do
-            setup_controller_for_warden
-          end
-
-          before(:each) do
-            warden
-          end
+          setup :setup_controller_for_warden, :warden if respond_to?(:setup)
         end
       end
 
@@ -31,7 +26,7 @@ module Warden
       # Quick access to Warden::Proxy.
       def warden
         @warden ||= begin
-          manager = Warden::Manager.new(nil, &Rails.application.config.middleware.detect{|m| m.name == 'RailsWarden::Manager'}.block)
+          manager = Warden::Manager.new(nil, &Rails.application.config.middleware.detect{|m| m.name == 'Warden::Manager'}.block)
           @request.env['warden'] = Warden::Proxy.new(@request.env, manager)
         end
       end


### PR DESCRIPTION
I have updated helper according to http://stackoverflow.com/questions/13420923/configuring-warden-for-use-in-rspec-controller-specs

Now it works with RoR 4.1 & RSpec 3.

Previously I got odd errors such as

```
     Failure/Error: Unable to find matching line from backtrace
     NoMethodError:
       undefined method `block' for nil:NilClass
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/warden-rspec-rails-0.1.0/lib/warden/test/controller_helpers.rb:34:in `warden'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/warden-rspec-rails-0.1.0/lib/warden/test/controller_helpers.rb:15:in `block (2 levels) in included'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:267:in `instance_exec'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:267:in `instance_exec'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:323:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:400:in `block in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:400:in `each'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:400:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:476:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:316:in `run_before_each'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:123:in `block in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:185:in `call'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:185:in `block (2 levels) in <class:Procsy>'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-rails-3.0.0.beta2/lib/rspec/rails/example/controller_example_group.rb:168:in `block (2 levels) in <module:ControllerExampleGroup>'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:267:in `instance_exec'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:267:in `instance_exec'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:420:in `block (2 levels) in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:185:in `call'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:185:in `block (2 levels) in <class:Procsy>'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-rails-3.0.0.beta2/lib/rspec/rails/adapters.rb:67:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:267:in `instance_exec'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:267:in `instance_exec'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:420:in `block (2 levels) in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:185:in `call'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:185:in `block (2 levels) in <class:Procsy>'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:422:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/hooks.rb:476:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:276:in `with_around_each_hooks'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example.rb:121:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:468:in `block in run_examples'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:464:in `map'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:464:in `run_examples'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:431:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:432:in `block in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:432:in `map'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:432:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:432:in `block in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:432:in `map'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/example_group.rb:432:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/command_line.rb:27:in `block (2 levels) in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/command_line.rb:27:in `map'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/command_line.rb:27:in `block in run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/reporter.rb:47:in `report'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/command_line.rb:24:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/runner.rb:100:in `run'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/lib/rspec/core/runner.rb:31:in `invoke'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/gems/rspec-core-3.0.0.beta2/exe/rspec:4:in `<top (required)>'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/bin/rspec:23:in `load'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/bin/rspec:23:in `<main>'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/bin/ruby_executable_hooks:15:in `eval'
     # /home/marcin/.rvm/gems/ruby-2.1.0@tuned-webapp/bin/ruby_executable_hooks:15:in `<main>'
     # 
     #   Showing full backtrace because every line was filtered out.
     #   See docs for RSpec::Configuration#backtrace_exclusion_patterns and
     #   RSpec::Configuration#backtrace_inclusion_patterns for more information.
```
