### PR TITLE
Fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## What
 
-Rails controller spec helpers for warden. If you're using warden
-without devise in rails, due to how action controller sets up the test
+Rails controller spec helpers for Warden. If you're using Warden
+without Devise in rails, due to how ActionController sets up the test
 environment, custom test setup code is necessary.
 
 ## Usage
@@ -15,12 +15,16 @@ end
 # spec_helper.rb
 RSpec.configure do |c|
   c.include Warden::Test::ControllerHelpers, type: :controller
-  
-  def sign_in(user)
-    warden.set_user(user)
-  end
 end
 ```
+
+This will define helper methods in controller tests that you can use to manage
+authentication, such as:
+- `warden`: Access the `Warden::Proxy`.
+- `login_as`: Same as the `Warden::Test::Helpers` `login_as` method.
+- `logout`: Same as the `Warden::Test::Helpers` `logout` method.
+- `unlogin`: Removes the user(s) from the logged-in list, but leaves the
+    session value so the user can be fetched on access.
 
 ## Thanks
 

--- a/lib/warden-rspec-rails.rb
+++ b/lib/warden-rspec-rails.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 
 require 'warden/test/controller_helpers'


### PR DESCRIPTION
- `require "warden"` first to prevent NameError exceptions.
- Make it Ruby 3+ compatible.
- Make it usable with Warden::Manager, so you don't have to use the
  RailsWarden gem and manager. Prevents NoMethodError on nil.
- Add Warden::Test::Helpers equivalent helper methods.
- Update the unauthenticated action handling to match newer Warden.
- Frozen string literals everywhere.
- Add docs of the helper methods to README.
- Proper name casing in README.

[Fixes #3, #7]